### PR TITLE
Robust web3 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbow-bridge-lib",
-  "version": "1.0.8",
+  "version": "2.0.0",
   "description": "Rainbow Bridge Lib",
   "author": "Near Inc.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbow-bridge-lib",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Rainbow Bridge Lib",
   "author": "Near Inc.",
   "repository": {

--- a/rainbow/robust.js
+++ b/rainbow/robust.js
@@ -32,11 +32,12 @@ class RobustWeb3 {
   async getBlockNumber() {
     return await backoff(RETRY, async () => {
       try {
-        return await this.web3.eth.getBlockNumber()
+        await this.web3.eth.getBlockNumber()
       } catch (e) {
         if (e && e.toString() === 'Error: connection not open') {
           this.web3.setProvider(this.ethNodeUrl)
         }
+        throw e
       }
     })
   }
@@ -44,11 +45,17 @@ class RobustWeb3 {
   async getBlock(b) {
     return await backoff(RETRY, async () => {
       try {
-        return await this.web3.eth.getBlock(b)
+        let block = await this.web3.eth.getBlock(b)
+        // sometimes infura gives null on the very new block, but retry works
+        if (block === null) {
+          // throw so backoff will do retry
+          throw new Error('web3.eth.getBlock returns null')
+        }
       } catch (e) {
         if (e && e.toString() === 'Error: connection not open') {
           this.web3.setProvider(this.ethNodeUrl)
         }
+        throw e
       }
     })
   }
@@ -149,6 +156,7 @@ class RobustWeb3 {
         if (e && e.toString() === 'Error: connection not open') {
           this.web3.setProvider(this.ethNodeUrl)
         }
+        throw e
       }
     })
   }
@@ -252,7 +260,7 @@ const signAndSendTransaction = async (
         await sendTxnAsync()
       }
     } catch (e) {
-      errorMsg = e.message;
+      errorMsg = e.message
       // sleep to avoid socket hangout on retry too soon
       await sleep(500)
       continue
@@ -272,7 +280,7 @@ const signAndSendTransaction = async (
           break
         }
       } catch (e) {
-        errorMsg = e.message;
+        errorMsg = e.message
         await sleep((j + 1) * 500)
       }
     }

--- a/rainbow/robust.js
+++ b/rainbow/robust.js
@@ -32,7 +32,7 @@ class RobustWeb3 {
   async getBlockNumber() {
     return await backoff(RETRY, async () => {
       try {
-        await this.web3.eth.getBlockNumber()
+        return await this.web3.eth.getBlockNumber()
       } catch (e) {
         if (e && e.toString() === 'Error: connection not open') {
           this.web3.setProvider(this.ethNodeUrl)

--- a/rainbow/robust.js
+++ b/rainbow/robust.js
@@ -51,6 +51,7 @@ class RobustWeb3 {
           // throw so backoff will do retry
           throw new Error('web3.eth.getBlock returns null')
         }
+        return block
       } catch (e) {
         if (e && e.toString() === 'Error: connection not open') {
           this.web3.setProvider(this.ethNodeUrl)


### PR DESCRIPTION
In today's rinkeby transfer token test, it fails at web3.eth.getBlock returns null. I found just retry very soon on infura it will return block.
Also, there is a bug in robustWeb3 methods that it doesn't re throw error, so backoff didn't retry (since there is no error)
Also, bump version to 2.0.0, since #13 introduce an incompatible change